### PR TITLE
Fixes in NoticeView

### DIFF
--- a/NoticeView/WBNoticeView/WBNoticeView.h
+++ b/NoticeView/WBNoticeView/WBNoticeView.h
@@ -8,10 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum WBNoticeViewSlidingMode {
+typedef NS_ENUM(NSUInteger, WBNoticeViewSlidingMode)  {
     WBNoticeViewSlidingModeUp,
     WBNoticeViewSlidingModeDown,
-} WBNoticeViewSlidingMode;
+};
 
 /**
  `WBNoticeView` objects provides a lightweight, non-intrusive means for displaying information to the user. The `WBNoticeView` class is an abstract class that encapsulates the interface common to all notice objects.

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -78,6 +78,10 @@
     return [self.title isEqual:object.title] && [self.message isEqual:object.message];
 }
 
+- (NSUInteger)hash {
+    return [self.title hash] + [self.message hash];
+}
+
 #pragma mark -
 
 - (void)displayNotice

--- a/NoticeView/WBNoticeView/WBNoticeView.m
+++ b/NoticeView/WBNoticeView/WBNoticeView.m
@@ -106,7 +106,7 @@
         self.gradientView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
     } else
     {
-        self.gradientView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
+        self.gradientView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
     }
     
     // Go ahead, display it
@@ -124,10 +124,7 @@
         [self registerObserver];
     } completion:^ (BOOL finished) {
         // if it's not sticky, hide it automatically
-        if ((self.tapToDismissEnabled && !self.isSticky) || (!self.tapToDismissEnabled && self.isSticky)) {
-            // Schedule a timer
-            self.displayTimer = [NSTimer scheduledTimerWithTimeInterval:self.delay target:self selector:@selector(dismissAfterTimerExpiration) userInfo:nil repeats:NO];
-        } else if (!self.isSticky) {
+        if (!self.isSticky) {
             // Display for a while, then hide it again
             [self dismissNoticeWithDuration:self.duration delay:self.delay hiddenYOrigin:self.hiddenYOrigin];
         }


### PR DESCRIPTION
Fixes the following issues:
- Uses `NS_ENUM` in `WBNoticeView` instead of `typedef enum`.
- Implements `-hash` method in `WBNoticeView` since `-isEqual` was also implemented.
- Changes top margin behaviour to work in landscape.
- Changes behaviour related to `sticky` and `tapToDismissEnabled`.
